### PR TITLE
[codex] Add LTX 2.3 GGUF workflow support and remote ComfyUI URLs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 minimum-release-age=10080
 audit=true
 save-exact=true
+node-linker=hoisted

--- a/COMFYUI_INTEGRATION_PLAN.md
+++ b/COMFYUI_INTEGRATION_PLAN.md
@@ -13,8 +13,8 @@ LTX-Desktop is a Lightricks Electron + React desktop app for video generation. I
 React Frontend (renderer)
     ↓ IPC (window.electronAPI)
 Electron Main Process (ComfyUI client + workflow builder)
-    ↓ HTTP + WebSocket (localhost:8188)
-ComfyUI Desktop (existing, running on 8188)
+    ↓ HTTP + WebSocket (configured ComfyUI URL)
+ComfyUI (local or remote)
 ```
 
 No Python backend. The Electron main process handles workflow building, image upload, progress tracking, and output retrieval directly.
@@ -46,6 +46,7 @@ No Python backend. The Electron main process handles workflow building, image up
 - `cancel(promptId)` → POST `/queue` with `{delete: [promptId]}`
 - `checkHealth()` → GET `/system_stats` → returns boolean
 - Configurable `comfyuiUrl` (default `http://localhost:8188`)
+- Accepts full URLs or bare `host:port` input, normalizes to HTTP, and probes the exact configured URL before any localhost fallback scan
 
 #### `electron/comfyui/progress.ts` — WebSocket progress tracker
 - Connects to `ws://localhost:8188/ws?clientId=<uuid>`
@@ -66,6 +67,11 @@ No Python backend. The Electron main process handles workflow building, image up
   - `frame_rate` ← fps
   - `seed` ← random or locked
   - `first_image` ← uploaded image ref (if I2V)
+- LTX 2.3 GGUF path:
+  - main model via `UnetLoaderGGUF`
+  - video VAE via standalone `VAELoader`
+  - audio VAE via `LTXVAudioVAELoader`
+  - standalone LTX text loading via `DualCLIPLoader` or `DualCLIPLoaderGGUF` plus embeddings connector
 
 #### `electron/comfyui/workflow-template.json` — Exported workflow
 - RSLTXVGenerate workflow exported from ComfyUI in API format
@@ -171,7 +177,7 @@ Messages:
 
 ## Verification
 
-1. Start ComfyUI Desktop on port 8188
+1. Start ComfyUI and confirm the configured ComfyUI URL is reachable
 2. Start LTX-Desktop (`pnpm dev`)
 3. App shows "Connected" (health check passes)
 4. Enter text prompt → ComfyUI generates video

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A desktop app for AI video and image generation using LTX models via ComfyUI. Fo
 - **Temporal upscale** (2x frame count)
 - **Film grain** post-processing with persistent settings
 - **Ollama prompt formatter** — local LLM reformats prompts into optimized tag format with positive/negative generation
-- **Model selector dropdowns** — choose checkpoint, text encoder, VAE, upscalers, and LoRA from what's installed in ComfyUI
+- **Model selector dropdowns** — choose regular or GGUF checkpoints, text encoders, video/audio VAEs, connector weights, upscalers, and LoRA from what's installed in ComfyUI
 - **Sampler selection** — all samplers available in your ComfyUI install (including custom ones like res samplers)
 - **Generation metadata embedding** — settings saved into video files via ffmpeg, loadable for re-use
 - **Progress labels** — stage-aware progress ("Generating first frame", "Generating video", "Rediffusing")
@@ -23,7 +23,7 @@ A desktop app for AI video and image generation using LTX models via ComfyUI. Fo
 
 ## Requirements
 
-- [ComfyUI](https://github.com/comfyanonymous/ComfyUI) running and accessible (default: `http://localhost:8188`)
+- [ComfyUI](https://github.com/comfyanonymous/ComfyUI) running and accessible from the desktop app. Local and remote URLs are both supported.
 - NVIDIA GPU with sufficient VRAM (16GB+ recommended, 24GB+ for 1080p with upscale)
 - LTX model weights (downloaded automatically during first-run setup)
 
@@ -61,7 +61,7 @@ On first launch, the setup wizard will:
 2. Download any missing LTX model weights
 3. Auto-install the required [rs-nodes](https://github.com/richservo/rs-nodes) and [RES4LYF](https://github.com/ClownsharkBatwing/RES4LYF) custom nodes into ComfyUI
 
-> **Note:** ComfyUI must be running before you launch the app (default: `http://localhost:8188`).
+> **Note:** ComfyUI must be running before you launch the app. The default URL is `http://localhost:8188`, but you can point the app at a different local or remote ComfyUI server from Settings.
 
 ## Architecture
 
@@ -105,11 +105,30 @@ Frontend (React) ──IPC──> Electron Main ──HTTP/WS──> ComfyUI
 
 Dropdowns populated from ComfyUI's `/object_info` API:
 
-- **Checkpoint** — main model (shared across checkpoint loader, text encoder loader, VAE loader)
-- **Audio VAE Checkpoint** — can differ from main checkpoint
+- **Checkpoint Format** — choose between regular `.safetensors` checkpoints and GGUF UNets
+- **Checkpoint** — main model selection
+- **Video VAE** — standalone video VAE used for LTX encode/decode
+- **Audio VAE** — asset used by the AV dual-tower path in `RSLTXVGenerate`
+- **Text Encoder Format** — choose regular or GGUF text loading
 - **Text Encoder** — text encoding model
+- **LTX Embeddings Connector** — connector weights paired with standalone LTX text loading
 - **Spatial Upscaler** / **Temporal Upscaler** — upscale models
 - **Upscale LoRA** — LoRA applied during spatial upscale
+
+### ComfyUI connection (Settings > General)
+
+- **ComfyUI URL** accepts either a full URL like `http://example-host:8188` or a bare host/port like `example-host:8188`
+- The app probes the exact configured URL first, so custom remote ports work without needing the default localhost port scan
+
+### LTX 2.3 GGUF notes
+
+- GGUF mode uses `UnetLoaderGGUF` for the main LTX 2.3 model
+- GGUF mode does not require a regular `.safetensors` main checkpoint
+- GGUF mode still expects the matching auxiliary LTX assets exposed by ComfyUI:
+  - video VAE
+  - audio VAE
+  - embeddings connector
+- Text loading in GGUF-aware paths is done through standalone CLIP loaders plus the connector asset rather than through the checkpoint-backed `LTXAVTextEncoderLoader`
 
 ### Playground controls
 

--- a/electron/comfyui/client.ts
+++ b/electron/comfyui/client.ts
@@ -25,15 +25,22 @@ export interface ComfyUIHistoryEntry {
   status: { status_str: string; completed: boolean }
 }
 
+function normalizeComfyUiUrl(url: string): string {
+  const trimmed = url.trim().replace(/\/$/, '')
+  if (!trimmed) return 'http://localhost:8188'
+  if (/^[a-z]+:\/\//i.test(trimmed)) return trimmed
+  return `http://${trimmed}`
+}
+
 export class ComfyUIClient {
   private baseUrl: string
 
   constructor(baseUrl = 'http://localhost:8188') {
-    this.baseUrl = baseUrl.replace(/\/$/, '')
+    this.baseUrl = normalizeComfyUiUrl(baseUrl)
   }
 
   setBaseUrl(url: string): void {
-    this.baseUrl = url.replace(/\/$/, '')
+    this.baseUrl = normalizeComfyUiUrl(url)
   }
 
   async submitWorkflow(
@@ -172,9 +179,25 @@ export class ComfyUIClient {
   }
 
   async checkHealth(): Promise<boolean> {
-    // Scan all common ComfyUI ports and use the highest one that responds
-    // (ComfyUI increments port when previous instance is still bound)
-    const baseHost = new URL(this.baseUrl).hostname
+    // Always probe the exact configured URL first so custom remote hosts and
+    // non-default ports work without being forced into the localhost scan.
+    if (await this.probeUrl(this.baseUrl)) {
+      return true
+    }
+
+    // For the default local ComfyUI setup, scan common fallback ports and use
+    // the highest one that responds (ComfyUI increments when a prior port is busy).
+    const parsedUrl = new URL(this.baseUrl)
+    const baseHost = parsedUrl.hostname
+    const basePort = parsedUrl.port
+    const shouldScanFallbackPorts =
+      ['localhost', '127.0.0.1'].includes(baseHost)
+      && (basePort === '' || (Number(basePort) >= 8188 && Number(basePort) <= 8199))
+
+    if (!shouldScanFallbackPorts) {
+      return false
+    }
+
     let bestUrl: string | null = null
 
     for (let port = 8188; port <= 8199; port++) {

--- a/electron/comfyui/client.ts
+++ b/electron/comfyui/client.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { getDefaultComfyUiUrl } from './defaults'
 import { logger } from '../logger'
 
 export interface ComfyUIUploadResult {
@@ -35,7 +36,7 @@ function normalizeComfyUiUrl(url: string): string {
 export class ComfyUIClient {
   private baseUrl: string
 
-  constructor(baseUrl = 'http://localhost:8188') {
+  constructor(baseUrl = getDefaultComfyUiUrl()) {
     this.baseUrl = normalizeComfyUiUrl(baseUrl)
   }
 

--- a/electron/comfyui/defaults.ts
+++ b/electron/comfyui/defaults.ts
@@ -1,0 +1,29 @@
+import { app } from 'electron'
+import path from 'path'
+
+function normalizeComfyUiUrl(url: string): string {
+  const trimmed = url.trim().replace(/\/$/, '')
+  if (!trimmed) return 'http://localhost:8188'
+  if (/^[a-z]+:\/\//i.test(trimmed)) return trimmed
+  return `http://${trimmed}`
+}
+
+export function getEnvComfyUiPath(): string | null {
+  const value = process.env.LTX_DESKTOP_COMFYUI_PATH?.trim()
+  return value ? path.resolve(value) : null
+}
+
+export function getDefaultComfyUiPath(): string {
+  return getEnvComfyUiPath() || path.join(app.getPath('documents'), 'ComfyUI')
+}
+
+export function getDefaultComfyUiUrl(): string {
+  return normalizeComfyUiUrl(process.env.LTX_DESKTOP_COMFYUI_URL || 'http://localhost:8188')
+}
+
+export function getDefaultComfyUiOutputDir(): string {
+  const comfyPath = getEnvComfyUiPath()
+  return comfyPath
+    ? path.join(comfyPath, 'output')
+    : path.join(app.getPath('documents'), 'ComfyUI', 'output')
+}

--- a/electron/comfyui/workflow-builder.ts
+++ b/electron/comfyui/workflow-builder.ts
@@ -51,11 +51,15 @@ export interface WorkflowParams {
   checkpoint?: string
   /** Text encoder model filename */
   textEncoder?: string
+  /** Embeddings connector used with GGUF text encoders */
+  ggufEmbeddingsConnector?: string
+  /** Standalone video VAE filename */
+  videoVae?: string
   /** Spatial upscale model filename */
   spatialUpscaleModel?: string
   /** Temporal upscale model filename */
   temporalUpscaleModel?: string
-  /** Audio VAE checkpoint filename (usually same as checkpoint) */
+  /** Audio VAE model filename loaded by LTXVAudioVAELoader */
   vaeCheckpoint?: string
   /** Upscale LoRA filename */
   upscaleLora?: string
@@ -176,6 +180,52 @@ function quantizeResolution(width: number, height: number, spatialUpscale: boole
   }
 }
 
+function isGGUFModel(filename?: string | null): boolean {
+  return !!filename && filename.toLowerCase().endsWith('.gguf')
+}
+
+function deriveLtxFamilyBase(assetName?: string | null): string | undefined {
+  if (!assetName) return undefined
+
+  let baseName = assetName.replace(/\.[^.]+$/, '')
+  baseName = baseName
+    .replace(/_(?:video_vae|audio_vae|embeddings_connectors)$/i, '')
+    .replace(/-(?:fp8|fp16|bf16|f16)$/i, '')
+    .replace(/-(?:[a-z0-9]+-)?q\d[\w.-]*$/i, '')
+
+  return baseName || undefined
+}
+
+function deriveLtxEmbeddingsConnectorFilename(assetName?: string | null): string | undefined {
+  if (!assetName) return undefined
+  if (assetName.endsWith('_embeddings_connectors.safetensors')) {
+    return assetName
+  }
+
+  const baseName = deriveLtxFamilyBase(assetName)
+  return baseName ? `${baseName}_embeddings_connectors.safetensors` : undefined
+}
+
+function deriveLtxVideoVaeFilename(assetName?: string | null): string | undefined {
+  if (!assetName) return undefined
+  if (assetName.endsWith('_video_vae.safetensors')) {
+    return assetName
+  }
+
+  const baseName = deriveLtxFamilyBase(assetName)
+  return baseName ? `${baseName}_video_vae.safetensors` : undefined
+}
+
+function deriveLtxAudioVaeFilename(assetName?: string | null): string | undefined {
+  if (!assetName) return undefined
+  if (assetName.endsWith('_audio_vae.safetensors')) {
+    return assetName
+  }
+
+  const baseName = deriveLtxFamilyBase(assetName)
+  return baseName ? `${baseName}_audio_vae.safetensors` : undefined
+}
+
 /**
  * Nodes that are only included when needed.
  * The core pipeline (1,4,5,6,7,8,23,24,25) is always included.
@@ -223,6 +273,7 @@ const OPTIONAL_NODE_IDS = {
   maskOriginalSize: '108',
   maskSam2: '109',
   maskPaintImage: '110',
+  videoVae: '111',
 }
 
 const OLLAMA_FORMATTER_NODES = [
@@ -372,6 +423,16 @@ const DEFAULT_NEGATIVE_PROMPT = 'worst quality, low quality, blurry, jittery, di
 export function buildWorkflow(params: WorkflowParams): Record<string, unknown> {
   // Deep clone the template
   const workflow: Workflow = JSON.parse(JSON.stringify(workflowTemplate))
+  const checkpointIsGGUF = isGGUFModel(params.checkpoint)
+  const textEncoderIsGGUF = isGGUFModel(params.textEncoder)
+  const derivedAssetSource = params.checkpoint || params.videoVae || params.vaeCheckpoint
+  const resolvedVideoVae = checkpointIsGGUF
+    ? (params.videoVae || deriveLtxVideoVaeFilename(derivedAssetSource))
+    : params.videoVae
+  const resolvedAudioVae = params.vaeCheckpoint
+    || (checkpointIsGGUF ? deriveLtxAudioVaeFilename(derivedAssetSource) : params.checkpoint)
+  const resolvedEmbeddingsConnector = params.ggufEmbeddingsConnector
+    || deriveLtxEmbeddingsConnectorFilename(derivedAssetSource)
 
   const useZImage = params.imageGenerator === 'z-image'
 
@@ -476,17 +537,74 @@ export function buildWorkflow(params: WorkflowParams): Record<string, unknown> {
   }
 
   // --- Patch model selections ---
-  if (params.checkpoint) {
-    workflow['1'].inputs['ckpt_name'] = params.checkpoint
-    workflow['4'].inputs['ckpt_name'] = params.checkpoint
-  }
-  if (params.vaeCheckpoint) {
-    workflow['5'].inputs['ckpt_name'] = params.vaeCheckpoint
+  if (checkpointIsGGUF) {
+    if (!params.checkpoint) {
+      throw new Error('GGUF workflow requires a GGUF checkpoint filename')
+    }
+    if (!resolvedVideoVae) {
+      throw new Error('GGUF checkpoints require an LTX 2.3 video VAE (.safetensors)')
+    }
+
+    workflow['1'] = {
+      class_type: 'UnetLoaderGGUF',
+      inputs: {
+        unet_name: params.checkpoint,
+      },
+      _meta: { title: 'Load GGUF Checkpoint' },
+    }
+
+    workflow[OPTIONAL_NODE_IDS.videoVae] = {
+      class_type: 'VAELoader',
+      inputs: {
+        vae_name: resolvedVideoVae,
+      },
+      _meta: { title: 'LTX Video VAE' },
+    }
   } else if (params.checkpoint) {
-    workflow['5'].inputs['ckpt_name'] = params.checkpoint
+    workflow['1'].inputs['ckpt_name'] = params.checkpoint
   }
-  if (params.textEncoder) {
-    workflow['4'].inputs['text_encoder'] = params.textEncoder
+
+  const needsStandaloneTextEncoder = checkpointIsGGUF || textEncoderIsGGUF
+  if (needsStandaloneTextEncoder) {
+    if (!params.textEncoder) {
+      throw new Error('LTX text encoder path is missing')
+    }
+    if (!resolvedEmbeddingsConnector) {
+      throw new Error('Standalone LTX text encoders require an LTX 2.3 embeddings connector (.safetensors)')
+    }
+
+    workflow['4'] = {
+      class_type: textEncoderIsGGUF ? 'DualCLIPLoaderGGUF' : 'DualCLIPLoader',
+      inputs: {
+        clip_name1: params.textEncoder,
+        clip_name2: resolvedEmbeddingsConnector,
+        type: 'ltxv',
+      },
+      _meta: { title: textEncoderIsGGUF ? 'LTXV GGUF Text Encoder Loader' : 'LTXV Text Encoder Loader' },
+    }
+  } else {
+    if (params.checkpoint) {
+      workflow['4'].inputs['ckpt_name'] = params.checkpoint
+    }
+    if (params.textEncoder) {
+      workflow['4'].inputs['text_encoder'] = params.textEncoder
+    }
+  }
+
+  if (checkpointIsGGUF && !resolvedAudioVae) {
+    throw new Error('GGUF checkpoints require an LTX 2.3 audio VAE asset')
+  }
+  if (resolvedAudioVae) {
+    workflow['5'].inputs['ckpt_name'] = resolvedAudioVae
+  }
+  if (resolvedVideoVae && !checkpointIsGGUF) {
+    workflow[OPTIONAL_NODE_IDS.videoVae] = {
+      class_type: 'VAELoader',
+      inputs: {
+        vae_name: resolvedVideoVae,
+      },
+      _meta: { title: 'LTX Video VAE' },
+    }
   }
   if (params.spatialUpscaleModel && workflow['2']) {
     workflow['2'].inputs['model_name'] = params.spatialUpscaleModel
@@ -507,6 +625,9 @@ export function buildWorkflow(params: WorkflowParams): Record<string, unknown> {
   if (params.upscaleDenoise !== undefined) {
     genNode.inputs['upscale_denoise'] = params.upscaleDenoise
   }
+  genNode.inputs['vae'] = workflow[OPTIONAL_NODE_IDS.videoVae]
+    ? [OPTIONAL_NODE_IDS.videoVae, 0]
+    : ['1', 2]
 
   // Connect sampler node
   if (params.sampler) {

--- a/electron/ipc/comfyui-handlers.ts
+++ b/electron/ipc/comfyui-handlers.ts
@@ -275,6 +275,8 @@ export function registerComfyUIHandlers(): void {
         lastStrength: params.lastStrength,
         checkpoint: settings.checkpoint,
         textEncoder: settings.textEncoder,
+        ggufEmbeddingsConnector: settings.ggufEmbeddingsConnector,
+        videoVae: settings.videoVae,
         vaeCheckpoint: settings.vaeCheckpoint,
         spatialUpscaleModel: settings.spatialUpscaleModel,
         temporalUpscaleModel: settings.temporalUpscaleModel,
@@ -627,7 +629,28 @@ export function registerComfyUIHandlers(): void {
 
       const result = {
         checkpoints: extractOptions('CheckpointLoaderSimple', 'ckpt_name'),
+        modelCheckpoints: Array.from(new Set([
+          ...extractOptions('CheckpointLoaderSimple', 'ckpt_name'),
+          ...extractOptions('UnetLoaderGGUF', 'unet_name'),
+        ])).sort((a, b) => a.localeCompare(b)),
+        videoVaes: Array.from(new Set(
+          extractOptions('VAELoader', 'vae_name'),
+        )).sort((a, b) => a.localeCompare(b)),
+        audioVaes: Array.from(new Set(
+          extractOptions('LTXVAudioVAELoader', 'ckpt_name'),
+        )).sort((a, b) => a.localeCompare(b)),
         textEncoders: extractOptions('LTXAVTextEncoderLoader', 'text_encoder'),
+        ggufTextEncoders: Array.from(new Set([
+          ...extractOptions('DualCLIPLoaderGGUF', 'clip_name1'),
+          ...extractOptions('CLIPLoaderGGUF', 'clip_name'),
+        ]))
+          .filter(name => name.toLowerCase().endsWith('.gguf'))
+          .sort((a, b) => a.localeCompare(b)),
+        ggufEmbeddingsConnectors: Array.from(new Set(
+          extractOptions('DualCLIPLoaderGGUF', 'clip_name2'),
+        ))
+          .filter(name => name.toLowerCase().endsWith('_embeddings_connectors.safetensors'))
+          .sort((a, b) => a.localeCompare(b)),
         upscaleModels: extractOptions('LatentUpscaleModelLoader', 'model_name'),
         loras: extractOptions('RSLTXVGenerate', 'upscale_lora'),
         samplers: extractOptions('KSamplerSelect', 'sampler_name'),
@@ -639,11 +662,11 @@ export function registerComfyUIHandlers(): void {
         geminiAspectRatios: extractOptions('Gemini3ProImage', 'aspect_ratio'),
         geminiImageSizes: extractOptions('Gemini3ProImage', 'image_size'),
       }
-      logger.info(`comfyui:model-lists counts: checkpoints=${result.checkpoints.length}, textEncoders=${result.textEncoders.length}, upscaleModels=${result.upscaleModels.length}, loras=${result.loras.length}, samplers=${result.samplers.length}, rtxSuperRes=${result.hasRtxSuperRes}, zImage=${result.hasZImage}, gemini=${result.hasGemini}`)
+      logger.info(`comfyui:model-lists counts: checkpoints=${result.checkpoints.length}, modelCheckpoints=${result.modelCheckpoints.length}, videoVaes=${result.videoVaes.length}, audioVaes=${result.audioVaes.length}, textEncoders=${result.textEncoders.length}, ggufTextEncoders=${result.ggufTextEncoders.length}, ggufEmbeddingsConnectors=${result.ggufEmbeddingsConnectors.length}, upscaleModels=${result.upscaleModels.length}, loras=${result.loras.length}, samplers=${result.samplers.length}, rtxSuperRes=${result.hasRtxSuperRes}, zImage=${result.hasZImage}, gemini=${result.hasGemini}`)
       return result
     } catch (error) {
       logger.error(`Failed to fetch model lists: ${error}`)
-      return { checkpoints: [], textEncoders: [], upscaleModels: [], loras: [] }
+      return { checkpoints: [], modelCheckpoints: [], videoVaes: [], audioVaes: [], textEncoders: [], ggufTextEncoders: [], ggufEmbeddingsConnectors: [], upscaleModels: [], loras: [], samplers: [] }
     }
   })
 

--- a/electron/ipc/settings-handlers.ts
+++ b/electron/ipc/settings-handlers.ts
@@ -20,6 +20,8 @@ export interface ComfyUISettings {
   filmGrainSize: number
   checkpoint: string
   textEncoder: string
+  ggufEmbeddingsConnector: string
+  videoVae: string
   vaeCheckpoint: string
   spatialUpscaleModel: string
   temporalUpscaleModel: string
@@ -52,7 +54,9 @@ function getDefaultSettings(): ComfyUISettings {
     filmGrainSize: 1.2,
     checkpoint: 'ltx-2.3-22b-dev-fp8.safetensors',
     textEncoder: 'gemma_3_12B_it_fp4_mixed.safetensors',
-    vaeCheckpoint: 'ltx-2.3-22b-dev-fp8.safetensors',
+    ggufEmbeddingsConnector: '',
+    videoVae: '',
+    vaeCheckpoint: '',
     spatialUpscaleModel: 'ltx-2.3-spatial-upscaler-x2-1.0.safetensors',
     temporalUpscaleModel: 'ltx-2.3-temporal-upscaler-x2-1.0.safetensors',
     upscaleLora: 'ltx-2.3-22b-distilled-lora-384.safetensors',
@@ -103,11 +107,20 @@ export function registerSettingsHandlers(): void {
     'settings:update',
     (_event, patch: Partial<ComfyUISettings>) => {
       const current = getComfyUISettings()
-      const updated = { ...current, ...patch }
+      const normalizedPatch = { ...patch }
+      if (typeof normalizedPatch.comfyuiUrl === 'string') {
+        const trimmed = normalizedPatch.comfyuiUrl.trim()
+        normalizedPatch.comfyuiUrl = trimmed
+          ? (/^[a-z]+:\/\//i.test(trimmed)
+            ? trimmed.replace(/\/$/, '')
+            : `http://${trimmed.replace(/\/$/, '')}`)
+          : current.comfyuiUrl
+      }
+      const updated = { ...current, ...normalizedPatch }
       saveComfyUISettings(updated)
 
       // If URL changed, update the client
-      if (patch.comfyuiUrl) {
+      if (normalizedPatch.comfyuiUrl) {
         comfyClient.setBaseUrl(updated.comfyuiUrl)
       }
 

--- a/electron/ipc/settings-handlers.ts
+++ b/electron/ipc/settings-handlers.ts
@@ -2,6 +2,11 @@ import { app, ipcMain } from 'electron'
 import fs from 'fs'
 import path from 'path'
 import { comfyClient } from '../comfyui/client'
+import {
+  getDefaultComfyUiOutputDir,
+  getDefaultComfyUiPath,
+  getDefaultComfyUiUrl,
+} from '../comfyui/defaults'
 import { logger } from '../logger'
 
 export interface ComfyUISettings {
@@ -37,11 +42,10 @@ export interface ComfyUISettings {
 }
 
 function getDefaultSettings(): ComfyUISettings {
-  const docsDir = app.getPath('documents')
   return {
-    comfyuiUrl: 'http://localhost:8188',
-    comfyuiOutputDir: path.join(docsDir, 'ComfyUI', 'output'),
-    comfyuiPath: '',
+    comfyuiUrl: getDefaultComfyUiUrl(),
+    comfyuiOutputDir: getDefaultComfyUiOutputDir(),
+    comfyuiPath: getDefaultComfyUiPath(),
     seedLocked: false,
     lockedSeed: 42,
     steps: 30,

--- a/electron/ipc/setup-handlers.ts
+++ b/electron/ipc/setup-handlers.ts
@@ -1,9 +1,8 @@
 import { ipcMain } from 'electron'
 import fs from 'fs'
-import os from 'os'
-import path from 'path'
 import { checkExistingModels, downloadModels } from '../comfyui/model-downloader'
 import { installRsNodes } from '../comfyui/rs-nodes-installer'
+import { getDefaultComfyUiPath } from '../comfyui/defaults'
 import { logger } from '../logger'
 import { getMainWindow } from '../window'
 
@@ -11,7 +10,7 @@ let installAbortController: AbortController | null = null
 
 export function registerSetupHandlers(): void {
   ipcMain.handle('setup:get-default-comfy-path', () => {
-    return path.join(os.homedir(), 'Documents', 'ComfyUI')
+    return getDefaultComfyUiPath()
   })
 
   ipcMain.handle(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -158,7 +158,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('comfyui:find-stack-output', params),
   checkComfyUIHealth: (): Promise<{ connected: boolean }> =>
     ipcRenderer.invoke('comfyui:health'),
-  getModelLists: (): Promise<{ checkpoints: string[]; textEncoders: string[]; upscaleModels: string[]; loras: string[]; samplers: string[]; hasZImage?: boolean; hasGemini?: boolean; geminiModels?: string[]; geminiAspectRatios?: string[]; geminiImageSizes?: string[] }> =>
+  getModelLists: (): Promise<{ checkpoints: string[]; modelCheckpoints?: string[]; videoVaes?: string[]; audioVaes?: string[]; textEncoders: string[]; ggufTextEncoders?: string[]; ggufEmbeddingsConnectors?: string[]; upscaleModels: string[]; loras: string[]; samplers: string[]; hasZImage?: boolean; hasGemini?: boolean; geminiModels?: string[]; geminiAspectRatios?: string[]; geminiImageSizes?: string[] }> =>
     ipcRenderer.invoke('comfyui:model-lists'),
   readVideoMetadata: (filePath: string): Promise<Record<string, unknown> | null> =>
     ipcRenderer.invoke('comfyui:read-video-metadata', filePath),
@@ -310,7 +310,7 @@ declare global {
       }>
       cancelGeneration: () => Promise<void>
       checkComfyUIHealth: () => Promise<{ connected: boolean }>
-      getModelLists: () => Promise<{ checkpoints: string[]; textEncoders: string[]; upscaleModels: string[]; loras: string[]; samplers: string[] }>
+      getModelLists: () => Promise<{ checkpoints: string[]; modelCheckpoints?: string[]; videoVaes?: string[]; audioVaes?: string[]; textEncoders: string[]; ggufTextEncoders?: string[]; ggufEmbeddingsConnectors?: string[]; upscaleModels: string[]; loras: string[]; samplers: string[] }>
       readVideoMetadata: (filePath: string) => Promise<Record<string, unknown> | null>
       renderGuideVideo: (params: { images: { path: string; startFrame: number; endFrame: number }[]; fps: number; totalFrames: number; resolution: string; aspectRatio: string }) => Promise<string>
       padAudioToLength: (params: { sourcePath: string; targetDuration: number }) => Promise<string>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -115,7 +115,7 @@ function AppContent() {
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <h2 className="text-xl font-semibold text-foreground mb-2">Cannot Connect to ComfyUI</h2>
           <p className="text-muted-foreground mb-4">{backendError}</p>
-          <p className="text-muted-foreground text-sm mb-4">Make sure ComfyUI Desktop is running on port 8188.</p>
+          <p className="text-muted-foreground text-sm mb-4">Make sure the configured ComfyUI server is running and reachable.</p>
           <Button onClick={() => window.location.reload()}>Retry</Button>
         </div>
       </div>

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { Info, Package, Settings, Sliders, X, RefreshCw, CheckCircle, AlertTriangle, Download } from 'lucide-react'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Button } from './ui/button'
 import { useAppSettings, DEFAULT_APP_SETTINGS, type AppSettings } from '../contexts/AppSettingsContext'
 import { logger } from '../lib/logger'
@@ -11,6 +11,27 @@ interface SettingsModalProps {
 }
 
 type TabId = 'general' | 'inference' | 'models' | 'about'
+type ModelFormat = 'regular' | 'gguf'
+
+function isGGUFFile(name: string): boolean {
+  return name.toLowerCase().endsWith('.gguf')
+}
+
+function deriveLtxFamilyBase(assetName: string): string {
+  return assetName
+    .replace(/\.[^.]+$/, '')
+    .replace(/_(?:video_vae|audio_vae|embeddings_connectors)$/i, '')
+    .replace(/-(?:fp8|fp16|bf16|f16)$/i, '')
+    .replace(/-(?:[a-z0-9]+-)?q\d[\w.-]*$/i, '')
+}
+
+function deriveLtxAssetName(assetName: string, suffix: '_video_vae' | '_audio_vae' | '_embeddings_connectors'): string {
+  if (assetName.endsWith(`${suffix}.safetensors`)) {
+    return assetName
+  }
+
+  return `${deriveLtxFamilyBase(assetName)}${suffix}.safetensors`
+}
 
 export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProps) {
   const { settings, updateSettings } = useAppSettings()
@@ -22,9 +43,11 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const [modelLicenseText, setModelLicenseText] = useState<string | null>(null)
   const [modelLicenseLoading, setModelLicenseLoading] = useState(false)
   const [showModelLicense, setShowModelLicense] = useState(false)
-  const [modelLists, setModelLists] = useState<{ checkpoints: string[]; textEncoders: string[]; upscaleModels: string[]; loras: string[]; samplers: string[]; hasZImage?: boolean; hasGemini?: boolean; geminiModels?: string[]; geminiAspectRatios?: string[]; geminiImageSizes?: string[] } | null>(null)
+  const [modelLists, setModelLists] = useState<{ checkpoints: string[]; modelCheckpoints?: string[]; videoVaes?: string[]; audioVaes?: string[]; textEncoders: string[]; ggufTextEncoders?: string[]; ggufEmbeddingsConnectors?: string[]; upscaleModels: string[]; loras: string[]; samplers: string[]; hasZImage?: boolean; hasGemini?: boolean; geminiModels?: string[]; geminiAspectRatios?: string[]; geminiImageSizes?: string[] } | null>(null)
   const [modelListsLoading, setModelListsLoading] = useState(false)
   const [modelListsError, setModelListsError] = useState<string | null>(null)
+  const [checkpointFormat, setCheckpointFormat] = useState<ModelFormat>('regular')
+  const [textEncoderFormat, setTextEncoderFormat] = useState<ModelFormat>('regular')
   const [comfyUrlInput, setComfyUrlInput] = useState(settings.comfyuiUrl)
   const [comfyOutputDirInput, setComfyOutputDirInput] = useState(settings.comfyuiOutputDir)
   const [ollamaUrlInput, setOllamaUrlInput] = useState(settings.ollamaUrl)
@@ -49,8 +72,48 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
       setComfyOutputDirInput(settings.comfyuiOutputDir)
       setOllamaUrlInput(settings.ollamaUrl)
       setOllamaModelInput(settings.ollamaModel)
+      setCheckpointFormat(isGGUFFile(settings.checkpoint) ? 'gguf' : 'regular')
+      setTextEncoderFormat(isGGUFFile(settings.textEncoder) ? 'gguf' : 'regular')
     }
   }, [isOpen, settings.comfyuiUrl, settings.comfyuiOutputDir, settings.ollamaUrl, settings.ollamaModel])
+
+  const regularCheckpointOptions = modelLists?.checkpoints ?? []
+  const videoVaeOptions = modelLists?.videoVaes ?? []
+  const audioVaeOptions = modelLists?.audioVaes ?? []
+  const ggufCheckpointOptions = useMemo(
+    () => (modelLists?.modelCheckpoints ?? []).filter(isGGUFFile),
+    [modelLists],
+  )
+  const regularTextEncoderOptions = modelLists?.textEncoders ?? []
+  const ggufTextEncoderOptions = modelLists?.ggufTextEncoders ?? []
+  const ggufEmbeddingsConnectorOptions = modelLists?.ggufEmbeddingsConnectors ?? []
+  const checkpointOptions = checkpointFormat === 'gguf' ? ggufCheckpointOptions : regularCheckpointOptions
+  const textEncoderOptions = textEncoderFormat === 'gguf' ? ggufTextEncoderOptions : regularTextEncoderOptions
+  const defaultVideoVae = useMemo(() => {
+    if (videoVaeOptions.length === 0) return ''
+    const derived = deriveLtxAssetName(settings.checkpoint, '_video_vae')
+    return videoVaeOptions.includes(derived)
+      ? derived
+      : ''
+  }, [settings.checkpoint, videoVaeOptions])
+  const defaultAudioVae = useMemo(() => {
+    if (audioVaeOptions.length === 0) return ''
+    const derived = deriveLtxAssetName(settings.checkpoint, '_audio_vae')
+    if (audioVaeOptions.includes(derived)) {
+      return derived
+    }
+    if (audioVaeOptions.includes(settings.checkpoint)) {
+      return settings.checkpoint
+    }
+    return audioVaeOptions[0]
+  }, [audioVaeOptions, settings.checkpoint])
+  const defaultEmbeddingsConnector = useMemo(() => {
+    if (ggufEmbeddingsConnectorOptions.length === 0) return ''
+    const derived = deriveLtxAssetName(settings.checkpoint, '_embeddings_connectors')
+    return ggufEmbeddingsConnectorOptions.includes(derived)
+      ? derived
+      : ggufEmbeddingsConnectorOptions[0]
+  }, [ggufEmbeddingsConnectorOptions, settings.checkpoint])
 
   useEffect(() => {
     if (activeTab !== 'models' && activeTab !== 'inference') return
@@ -72,6 +135,42 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     if (activeTab !== 'about' || appVersion) return
     window.electronAPI.getAppInfo().then(info => setAppVersion(info.version)).catch(() => {})
   }, [activeTab, appVersion])
+
+  useEffect(() => {
+    if (!modelLists) return
+
+    const patch: Partial<AppSettings> = {}
+    if (
+      defaultVideoVae
+      && (!settings.videoVae || !videoVaeOptions.includes(settings.videoVae))
+    ) {
+      patch.videoVae = defaultVideoVae
+    }
+    if (defaultAudioVae && (!settings.vaeCheckpoint || !audioVaeOptions.includes(settings.vaeCheckpoint))) {
+      patch.vaeCheckpoint = defaultAudioVae
+    }
+    if (
+      defaultEmbeddingsConnector
+      && (!settings.ggufEmbeddingsConnector || !ggufEmbeddingsConnectorOptions.includes(settings.ggufEmbeddingsConnector))
+    ) {
+      patch.ggufEmbeddingsConnector = defaultEmbeddingsConnector
+    }
+    if (Object.keys(patch).length > 0) {
+      updateSettings(patch)
+    }
+  }, [
+    audioVaeOptions,
+    defaultAudioVae,
+    defaultEmbeddingsConnector,
+    defaultVideoVae,
+    ggufEmbeddingsConnectorOptions,
+    modelLists,
+    settings.ggufEmbeddingsConnector,
+    settings.vaeCheckpoint,
+    settings.videoVae,
+    updateSettings,
+    videoVaeOptions,
+  ])
 
   if (!isOpen) return null
 
@@ -96,6 +195,33 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const handleCfgChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const cfg = Math.max(0, Math.min(30, parseFloat(e.target.value) || 1.0))
     updateSettings({ cfg })
+  }
+
+  const handleCheckpointFormatChange = (nextFormat: ModelFormat) => {
+    setCheckpointFormat(nextFormat)
+    const nextOptions = nextFormat === 'gguf' ? ggufCheckpointOptions : regularCheckpointOptions
+    if (nextOptions.length > 0 && !nextOptions.includes(settings.checkpoint)) {
+      updateSettings({ checkpoint: nextOptions[0] })
+    }
+  }
+
+  const handleTextEncoderFormatChange = (nextFormat: ModelFormat) => {
+    setTextEncoderFormat(nextFormat)
+    const nextOptions = nextFormat === 'gguf' ? ggufTextEncoderOptions : regularTextEncoderOptions
+    const patch: Partial<AppSettings> = {}
+    if (nextOptions.length > 0 && !nextOptions.includes(settings.textEncoder)) {
+      patch.textEncoder = nextOptions[0]
+    }
+    if (
+      (checkpointFormat === 'gguf' || nextFormat === 'gguf') &&
+      defaultEmbeddingsConnector &&
+      !settings.ggufEmbeddingsConnector
+    ) {
+      patch.ggufEmbeddingsConnector = defaultEmbeddingsConnector
+    }
+    if (Object.keys(patch).length > 0) {
+      updateSettings(patch)
+    }
   }
 
   const handleSaveComfyUrl = () => {
@@ -221,12 +347,13 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
               <div className="space-y-3">
                 <h3 className="text-sm font-semibold text-white">ComfyUI Connection</h3>
                 <div className="bg-zinc-800/50 rounded-lg p-4 space-y-3">
-                  <div>
-                    <label className="text-xs text-zinc-400 mb-1 block">ComfyUI URL</label>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        value={comfyUrlInput}
+                    <div>
+                      <label className="text-xs text-zinc-400 mb-1 block">ComfyUI URL</label>
+                      <p className="text-xs text-zinc-500 mb-1">Accepts local or remote servers. You can paste either a full URL like `http://example-host:8188` or just `example-host:8188`.</p>
+                      <div className="flex gap-2">
+                        <input
+                          type="text"
+                          value={comfyUrlInput}
                         onChange={(e) => setComfyUrlInput(e.target.value)}
                         onKeyDown={(e) => e.stopPropagation()}
                         className="flex-1 px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -569,42 +696,97 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                 {modelLists && !modelListsLoading && (
                   <div className="bg-zinc-800/50 rounded-lg p-4 space-y-4">
                     <div>
+                      {ggufCheckpointOptions.length > 0 && (
+                        <>
+                          <label className="text-xs text-zinc-400 mb-1 block">Checkpoint Format</label>
+                          <select
+                            value={checkpointFormat}
+                            onChange={(e) => handleCheckpointFormatChange(e.target.value as ModelFormat)}
+                            className="w-full mb-2 px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          >
+                            <option value="regular">Regular (.safetensors)</option>
+                            <option value="gguf">GGUF (.gguf)</option>
+                          </select>
+                        </>
+                      )}
                       <label className="text-xs text-zinc-400 mb-1 block">Checkpoint</label>
-                      <p className="text-xs text-zinc-500 mb-1">Used by model loader and text encoder</p>
+                      <p className="text-xs text-zinc-500 mb-1">Main model loader. Switch format above to choose between standard checkpoints and GGUF UNets.</p>
                       <select
                         value={settings.checkpoint}
                         onChange={(e) => updateSettings({ checkpoint: e.target.value })}
                         className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                       >
-                        {modelLists.checkpoints.map((m) => (
+                        {checkpointOptions.map((m) => (
                           <option key={m} value={m}>{m}</option>
                         ))}
                       </select>
                     </div>
                     <div>
-                      <label className="text-xs text-zinc-400 mb-1 block">Audio VAE Checkpoint</label>
-                      <p className="text-xs text-zinc-500 mb-1">Usually same as checkpoint, but can differ</p>
+                      <label className="text-xs text-zinc-400 mb-1 block">Video VAE</label>
+                      <p className="text-xs text-zinc-500 mb-1">Standalone video VAE used for LTX encode/decode. GGUF checkpoints require this; regular checkpoints can override the built-in VAE with it.</p>
                       <select
-                        value={settings.vaeCheckpoint}
+                        value={settings.videoVae || defaultVideoVae}
+                        onChange={(e) => updateSettings({ videoVae: e.target.value })}
+                        className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      >
+                        {videoVaeOptions.map((m) => (
+                          <option key={m} value={m}>{m}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="text-xs text-zinc-400 mb-1 block">Audio VAE</label>
+                      <p className="text-xs text-zinc-500 mb-1">Used by the AV dual-tower path in `RSLTXVGenerate`. This is not the main model selection; pick the matching LTX audio VAE asset or compatible checkpoint-category file.</p>
+                      <select
+                        value={settings.vaeCheckpoint || defaultAudioVae}
                         onChange={(e) => updateSettings({ vaeCheckpoint: e.target.value })}
                         className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                       >
-                        {modelLists.checkpoints.map((m) => (
+                        {audioVaeOptions.map((m) => (
                           <option key={m} value={m}>{m}</option>
                         ))}
                       </select>
                     </div>
                     <div>
+                      {ggufTextEncoderOptions.length > 0 && (
+                        <>
+                          <label className="text-xs text-zinc-400 mb-1 block">Text Encoder Format</label>
+                          <select
+                            value={textEncoderFormat}
+                            onChange={(e) => handleTextEncoderFormatChange(e.target.value as ModelFormat)}
+                            className="w-full mb-2 px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          >
+                            <option value="regular">Regular</option>
+                            <option value="gguf">GGUF</option>
+                          </select>
+                        </>
+                      )}
                       <label className="text-xs text-zinc-400 mb-1 block">Text Encoder</label>
+                      <p className="text-xs text-zinc-500 mb-1">Choose the Gemma/T5 text encoder to pair with LTX. When the main model or text encoder is GGUF, the backend loads this together with the connector file directly instead of routing through a checkpoint.</p>
                       <select
                         value={settings.textEncoder}
                         onChange={(e) => updateSettings({ textEncoder: e.target.value })}
                         className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
                       >
-                        {modelLists.textEncoders.map((m) => (
+                        {textEncoderOptions.map((m) => (
                           <option key={m} value={m}>{m}</option>
                         ))}
                       </select>
+                      {(checkpointFormat === 'gguf' || textEncoderFormat === 'gguf') && ggufEmbeddingsConnectorOptions.length > 0 && (
+                        <>
+                          <label className="text-xs text-zinc-400 mt-3 mb-1 block">LTX Embeddings Connector</label>
+                          <p className="text-xs text-zinc-500 mb-1">Pairs the selected text encoder with the LTX 2.3 connector weights. Match this to the same model family as the main checkpoint or GGUF UNet.</p>
+                          <select
+                            value={settings.ggufEmbeddingsConnector || defaultEmbeddingsConnector}
+                            onChange={(e) => updateSettings({ ggufEmbeddingsConnector: e.target.value })}
+                            className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          >
+                            {ggufEmbeddingsConnectorOptions.map((m) => (
+                              <option key={m} value={m}>{m}</option>
+                            ))}
+                          </select>
+                        </>
+                      )}
                     </div>
                     <div>
                       <label className="text-xs text-zinc-400 mb-1 block">Spatial Upscaler</label>

--- a/frontend/contexts/AppSettingsContext.tsx
+++ b/frontend/contexts/AppSettingsContext.tsx
@@ -15,6 +15,8 @@ export interface AppSettings {
   filmGrainSize: number
   checkpoint: string
   textEncoder: string
+  ggufEmbeddingsConnector: string
+  videoVae: string
   vaeCheckpoint: string
   spatialUpscaleModel: string
   temporalUpscaleModel: string
@@ -44,7 +46,9 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   filmGrainSize: 1.2,
   checkpoint: 'ltx-2.3-22b-dev-fp8.safetensors',
   textEncoder: 'gemma_3_12B_it_fp4_mixed.safetensors',
-  vaeCheckpoint: 'ltx-2.3-22b-dev-fp8.safetensors',
+  ggufEmbeddingsConnector: '',
+  videoVae: '',
+  vaeCheckpoint: '',
   spatialUpscaleModel: 'ltx-2.3-spatial-upscaler-x2-1.0.safetensors',
   temporalUpscaleModel: 'ltx-2.3-temporal-upscaler-x2-1.0.safetensors',
   upscaleLora: 'ltx-2.3-22b-distilled-lora-384.safetensors',

--- a/frontend/hooks/use-backend.ts
+++ b/frontend/hooks/use-backend.ts
@@ -58,7 +58,7 @@ export function useBackend(): UseBackendReturn {
         setIsLoading(false)
         const currentStatus = await window.electronAPI.checkComfyUIHealth()
         if (!currentStatus.connected && !cancelled) {
-          setError('Could not connect to ComfyUI. Make sure ComfyUI Desktop is running on port 8188.')
+          setError('Could not connect to ComfyUI. Check the ComfyUI URL in Settings and make sure the server is reachable.')
         }
       }
     }

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -112,7 +112,7 @@ interface Window {
     cancelGeneration: () => Promise<void>
     findStackOutput: (params: { projectName: string; stackId: string }) => Promise<{ video_path: string; enhanced_prompt: string | null } | null>
     checkComfyUIHealth: () => Promise<{ connected: boolean }>
-    getModelLists: () => Promise<{ checkpoints: string[]; textEncoders: string[]; upscaleModels: string[]; loras: string[]; samplers: string[]; hasRtxSuperRes?: boolean; hasZImage?: boolean }>
+    getModelLists: () => Promise<{ checkpoints: string[]; modelCheckpoints?: string[]; videoVaes?: string[]; audioVaes?: string[]; textEncoders: string[]; ggufTextEncoders?: string[]; ggufEmbeddingsConnectors?: string[]; upscaleModels: string[]; loras: string[]; samplers: string[]; hasRtxSuperRes?: boolean; hasZImage?: boolean }>
     readVideoMetadata: (filePath: string) => Promise<Record<string, unknown> | null>
     extractAudioSegment: (params: { sourcePath: string; startTime: number; duration: number }) => Promise<string>
     renderGuideVideo: (params: { images: { path: string; startFrame: number; endFrame: number }[]; fps: number; totalFrames: number; resolution: string; aspectRatio: string }) => Promise<string>

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ws": "8.19.0"
   },
   "devDependencies": {
+    "@electron/get": "2.0.3",
     "@resvg/resvg-js": "^2.6.2",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.14.0",
@@ -56,6 +57,7 @@
     "cross-env": "^10.1.0",
     "electron": "^31.0.0",
     "electron-builder": "^26.8.1",
+    "extract-zip": "2.0.1",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
         specifier: 8.19.0
         version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
+      '@electron/get':
+        specifier: 2.0.3
+        version: 2.0.3
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -81,6 +84,9 @@ importers:
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      extract-zip:
+        specifier: 2.0.1
+        version: 2.0.1
       postcss:
         specifier: ^8.4.38
         version: 8.5.6

--- a/start.bat
+++ b/start.bat
@@ -101,41 +101,43 @@ if exist ".git" (
 :: -------------------------------------------------------
 :: 4. pnpm
 :: -------------------------------------------------------
-set "PNPM_CMD=pnpm"
+where npm >nul 2>&1
+if errorlevel 1 goto :npm_missing
 
-where corepack >nul 2>&1
-if errorlevel 1 goto :pnpm_global
-
-echo [*] Preparing pinned pnpm via corepack...
-call corepack enable >nul 2>&1
-call corepack prepare pnpm@10.30.3 --activate >nul 2>&1
-if errorlevel 1 goto :pnpm_global
-set "PNPM_CMD=corepack pnpm"
-goto :pnpm_ok
-
-:pnpm_global
 where pnpm >nul 2>&1
 if not errorlevel 1 goto :pnpm_ok
 
 echo [*] pnpm not found. Installing...
-call npm install -g pnpm >nul 2>&1
+call npm install -g pnpm
+if errorlevel 1 goto :pnpm_fail
+
 where pnpm >nul 2>&1
 if not errorlevel 1 goto :pnpm_ok
 
+:pnpm_fail
 echo.
 echo [ERROR] Failed to install pnpm.
 echo.
 pause
 exit /b 1
 
+:npm_missing
+
+echo.
+echo [ERROR] npm not found. Please install Node.js with npm support.
+echo.
+pause
+exit /b 1
+
 :pnpm_ok
+set "PNPM_CMD=pnpm"
 echo [OK] pnpm found.
 
 :: -------------------------------------------------------
 :: 5. Dependencies
 :: -------------------------------------------------------
 echo [*] Checking dependencies...
-call %PNPM_CMD% install --node-linker=hoisted
+call %PNPM_CMD% install
 if errorlevel 1 goto :deps_fail
 goto :deps_ok
 

--- a/start.bat
+++ b/start.bat
@@ -135,7 +135,7 @@ echo [OK] pnpm found.
 :: 5. Dependencies
 :: -------------------------------------------------------
 echo [*] Checking dependencies...
-call %PNPM_CMD% install
+call %PNPM_CMD% install --node-linker=hoisted
 if errorlevel 1 goto :deps_fail
 goto :deps_ok
 

--- a/start.bat
+++ b/start.bat
@@ -101,6 +101,19 @@ if exist ".git" (
 :: -------------------------------------------------------
 :: 4. pnpm
 :: -------------------------------------------------------
+set "PNPM_CMD=pnpm"
+
+where corepack >nul 2>&1
+if errorlevel 1 goto :pnpm_global
+
+echo [*] Preparing pinned pnpm via corepack...
+call corepack enable >nul 2>&1
+call corepack prepare pnpm@10.30.3 --activate >nul 2>&1
+if errorlevel 1 goto :pnpm_global
+set "PNPM_CMD=corepack pnpm"
+goto :pnpm_ok
+
+:pnpm_global
 where pnpm >nul 2>&1
 if not errorlevel 1 goto :pnpm_ok
 
@@ -122,7 +135,7 @@ echo [OK] pnpm found.
 :: 5. Dependencies
 :: -------------------------------------------------------
 echo [*] Checking dependencies...
-call pnpm install >nul 2>&1
+call %PNPM_CMD% install
 if errorlevel 1 goto :deps_fail
 goto :deps_ok
 
@@ -144,7 +157,7 @@ echo  ========================================
 echo   Launching LTX Desktop...
 echo  ========================================
 echo.
-call pnpm dev
+call %PNPM_CMD% dev
 if errorlevel 1 goto :launch_fail
 goto :launch_done
 


### PR DESCRIPTION
## What changed

This PR adds LTX 2.3 GGUF support to the ComfyUI-backed desktop flow and updates the app to work cleanly with configurable remote ComfyUI servers.

## GGUF workflow changes

- adds explicit GGUF main-model loading through `UnetLoaderGGUF`
- removes the incorrect hidden helper-checkpoint fallback for the main LTX 2.3 model
- routes GGUF LTX 2.3 generation through the real auxiliary assets ComfyUI/rs-nodes expect:
  - standalone video VAE
  - audio VAE
  - LTX embeddings connector
- updates text loading so GGUF-aware LTX paths use standalone dual CLIP loading plus the connector instead of checkpoint-backed text loading

## Desktop / settings changes

- adds explicit GUI selection for regular vs GGUF checkpoints
- adds explicit GUI selection for regular vs GGUF text encoders
- exposes `Video VAE`, `Audio VAE`, and `LTX Embeddings Connector` selections in Settings
- expands model discovery from ComfyUI `/object_info` so those asset lists are populated automatically

## Remote ComfyUI support

- keeps the existing configurable ComfyUI URL setting, but fixes the client so custom remote hosts and non-default ports work correctly
- normalizes bare `host:port` input to `http://host:port`
- makes health checks probe the exact configured URL first instead of assuming only localhost `8188-8199`
- updates the UI copy and error text to reflect remote-server support

## Docs / SOP

- updates the README and ComfyUI integration notes so the operating model matches the implementation
- documents the LTX 2.3 GGUF asset expectations and the remote ComfyUI URL behavior

## Why

The previous GGUF implementation path still assumed a regular safetensors helper checkpoint behind the scenes for the main LTX 2.3 flow, which is the wrong model-loading contract. The fix here is to treat the GGUF UNet as the main model and wire the remaining required LTX assets explicitly.

## Validation

- `corepack pnpm run typecheck:ts`

## Notes

This was validated against the current ComfyUI and rs-nodes loader contracts plus local TypeScript checks. I was not able to run a live end-to-end generation against the maintainer's ComfyUI instance from this environment.
